### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/articles/ml-openai-whisper-ft.md
+++ b/articles/ml-openai-whisper-ft.md
@@ -69,7 +69,7 @@ wav2vec2.0の学習対象であるLibriSpeechにおいて、Whisperはwav2vec2.0
 ! pip install jiwer
 ! pip install pyopenjtalk==0.3.0
 ! pip install pytorch-lightning==1.7.7
-! pip install -qqq evaluate==0.2.2
+! pip install -qqq evaluate==0.3.0
 ```
 
 ## audioの読み込み


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.